### PR TITLE
feat: Add ThemeProvider and refactor styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,23 +4,38 @@ import { useState } from "react";
 import { plugins, pluginById } from "./plugin-loader"; // from Step 1
 import PluginBar from "./plugin-ui/PluginBar";
 import PluginOutlet from "./plugin-ui/PluginOutlet";
+import { ThemeProvider } from 'styled-components';
+import { AppCommonStyles } from './CommonStyles';
+import { GlobalStyle } from './App.style.js';
 
 function App() {
   const [activeId, setActiveId] = useState(null);
+  const [theme, setTheme] = useState('light');
 
   const handlePluginClicked = (id) => {
     setActiveId(id === activeId ? null : id);
   }
 
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  const currentTheme = theme === 'light' ? AppCommonStyles.lightTheme : AppCommonStyles.darkTheme;
+  const themeProps = { ...currentTheme, ...AppCommonStyles.commonStyleProps };
+
   return (
-    <>
+    <ThemeProvider theme={themeProps}>
+      <GlobalStyle />
       <div>
         <img src={viteLogo} className="logo" alt="Vite logo" />
       </div>
       <h1>PluginApp</h1>
+      <button onClick={toggleTheme}>
+        Switch to {theme === 'light' ? 'Dark' : 'Light'} Theme
+      </button>
       <PluginBar plugins={plugins} activeId={activeId} onSelect={handlePluginClicked} />
       <PluginOutlet plugin={pluginById[activeId]} />
-    </>
+    </ThemeProvider>
   )
 }
 

--- a/src/App.style.js
+++ b/src/App.style.js
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const GlobalStyle = createGlobalStyle`
+  body {
+    background-color: ${props => props.theme.bgColor1};
+    color: ${props => props.theme.titleColor};
+    font-family: ${props => props.theme.fontFamily};
+  }
+`;

--- a/src/CommonStyles.js
+++ b/src/CommonStyles.js
@@ -1,0 +1,23 @@
+export const AppCommonStyles = {
+  commonStyleProps: {
+    fontFamily: 'sans-serif',
+  },
+  darkTheme: {
+    themeValue: 'dark',
+    titleColor: 'white',
+    bgColor1: '#232323',
+    button: {
+      bgColor: '#555',
+      textColor: 'white',
+    }
+  },
+  lightTheme: {
+    themeValue: 'light',
+    titleColor: 'black',
+    bgColor1: '#f0f0f0',
+    button: {
+      bgColor: '#ddd',
+      textColor: 'black',
+    }
+  }
+};

--- a/src/plugin-ui/PluginBar.jsx
+++ b/src/plugin-ui/PluginBar.jsx
@@ -1,13 +1,4 @@
-import styled from "styled-components";
-
-const Bar = styled.nav`
-  display: flex; gap: 8px; padding: 8px;
-  border-bottom: 1px solid #e5e7eb; background: #fafafa;
-`;
-const Item = styled.button`
-  padding: 6px 10px; border-radius: 10px; font: inherit; cursor: pointer;
-  border: 1px solid #e5e7eb; background: ${p => (p.$active ? "#eef2ff" : "white")};
-`;
+import { Bar, Item } from "./PluginBar.style.js";
 
 export default function PluginBar({ plugins, activeId, onSelect }) {
   return (

--- a/src/plugin-ui/PluginBar.style.js
+++ b/src/plugin-ui/PluginBar.style.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const Bar = styled.nav`
+  display: flex; gap: 8px; padding: 8px;
+  border-bottom: 1px solid #e5e7eb; background: #fafafa;
+`;
+
+export const Item = styled.button`
+  padding: 6px 10px; border-radius: 10px; font: inherit; cursor: pointer;
+  border: 1px solid #e5e7eb; background: ${p => (p.$active ? "#eef2ff" : "white")};
+`;

--- a/src/plugin-ui/PluginOutlet.jsx
+++ b/src/plugin-ui/PluginOutlet.jsx
@@ -10,19 +10,21 @@ class Boundary extends React.Component {
   }
 }
 
+import { OutletContainer, Info } from "./PluginOutlet.style.js";
+
 export default function PluginOutlet({ plugin }) {
   const Lazy = useMemo(() => plugin && React.lazy(plugin.load), [plugin?.id]); // load(): () => import('./index.jsx')
   return (
-    <div className="plugin-outlet">
+    <OutletContainer className="plugin-outlet">
       {!plugin ? (
-        <div style={{ padding: 12 }}>No plugin selected.</div>
+        <Info>No plugin selected.</Info>
       ) : (
-        <Boundary fallback={<div style={{ padding: 12 }}>Failed to load {plugin.title}.</div>}>
-          <Suspense fallback={<div style={{ padding: 12 }}>Loading {plugin.title}…</div>}>
+        <Boundary fallback={<Info>Failed to load {plugin.title}.</Info>}>
+          <Suspense fallback={<Info>Loading {plugin.title}…</Info>}>
             <Lazy />
           </Suspense>
         </Boundary>
       )}
-    </div>
+    </OutletContainer>
   );
 }

--- a/src/plugin-ui/PluginOutlet.style.js
+++ b/src/plugin-ui/PluginOutlet.style.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const OutletContainer = styled.div`
+  &.plugin-outlet {
+    // styles for plugin-outlet class if any
+  }
+`;
+
+export const Info = styled.div`
+  padding: 12px;
+`;

--- a/src/plugins/byebye/byebye.jsx
+++ b/src/plugins/byebye/byebye.jsx
@@ -1,0 +1,6 @@
+import { ByeByeContainer } from "./byebye.style.js";
+
+// src/plugins/hello/index.jsx
+export default function ByeBye() {
+  return <ByeByeContainer>ByeBye from the plugin. 👋</ByeByeContainer>;
+}

--- a/src/plugins/byebye/byebye.style.js
+++ b/src/plugins/byebye/byebye.style.js
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const ByeByeContainer = styled.div`
+  padding: 12px;
+`;

--- a/src/plugins/byebye/index.jsx
+++ b/src/plugins/byebye/index.jsx
@@ -1,4 +1,0 @@
-// src/plugins/hello/index.jsx
-export default function ByeBye() {
-  return <div style={{ padding: 12 }}>ByeBye from the plugin. 👋</div>;
-}

--- a/src/plugins/byebye/manifest.js
+++ b/src/plugins/byebye/manifest.js
@@ -4,5 +4,5 @@ export default {
   title: 'ByeBye',
   icon: '👋',
   // Lazy-load the plugin's root React component when needed
-  load: () => import('./index.jsx'),
+  load: () => import('./byebye.jsx'),
 };

--- a/src/plugins/hello/hello.jsx
+++ b/src/plugins/hello/hello.jsx
@@ -1,0 +1,6 @@
+import { HelloContainer } from "./hello.style.js";
+
+// src/plugins/hello/index.jsx
+export default function Hello() {
+  return <HelloContainer>👋 Hello from the plugin.</HelloContainer>;
+}

--- a/src/plugins/hello/hello.style.js
+++ b/src/plugins/hello/hello.style.js
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const HelloContainer = styled.div`
+  padding: 12px;
+`;

--- a/src/plugins/hello/index.jsx
+++ b/src/plugins/hello/index.jsx
@@ -1,4 +1,0 @@
-// src/plugins/hello/index.jsx
-export default function Hello() {
-  return <div style={{ padding: 12 }}>👋 Hello from the plugin.</div>;
-}

--- a/src/plugins/hello/manifest.js
+++ b/src/plugins/hello/manifest.js
@@ -4,5 +4,5 @@ export default {
   title: 'Hello',
   icon: '👋',
   // Lazy-load the plugin's root React component when needed
-  load: () => import('./index.jsx'),
+  load: () => import('./hello.jsx'),
 };

--- a/src/plugins/nowTime/manifest.js
+++ b/src/plugins/nowTime/manifest.js
@@ -4,5 +4,5 @@ export default {
   title: 'Now Time',
   icon: '⏰',
   // Lazy-load the plugin's root React component when needed
-  load: () => import('./index.jsx'),
+  load: () => import('./nowTime.jsx'),
 };

--- a/src/plugins/nowTime/nowTime.jsx
+++ b/src/plugins/nowTime/nowTime.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { TimeContainer } from './nowTime.style.js';
 
 export default function NowTime() {
   const [time, setTime] = useState(new Date());
@@ -11,5 +12,5 @@ export default function NowTime() {
     return () => clearInterval(intervalId);
   }, []);
 
-  return <div style={{ padding: 12 }}>{time.toLocaleTimeString()}</div>;
+  return <TimeContainer>{time.toLocaleTimeString()}</TimeContainer>;
 }

--- a/src/plugins/nowTime/nowTime.style.js
+++ b/src/plugins/nowTime/nowTime.style.js
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const TimeContainer = styled.div`
+  padding: 12px;
+`;


### PR DESCRIPTION
This commit introduces a theming solution using styled-components and refactors the existing styling to be more modular.

- Adds a `ThemeProvider` to `App.jsx` to enable theme switching.
- Creates a `CommonStyles.js` file for theme configurations (light and dark).
- Adds a button to toggle between light and dark themes.
- Extracts styled-components and inline styles from all components into separate `.style.js` files. This includes `App.jsx`, `PluginBar.jsx`, `PluginOutlet.jsx`, and all plugin components.
- Refactors the plugin file structure to be more consistent, with each plugin having a `pluginName.jsx` and a `pluginName.style.js` file.
- Updates plugin manifests to point to the new file names.