### PR TITLE
feat: Install MobX and add a generic store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "my-plugin-try",
       "version": "0.0.0",
       "dependencies": {
+        "mobx": "^6.13.7",
+        "mobx-react": "^9.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "styled-components": "^6.1.19"
@@ -2311,6 +2313,66 @@
         "node": "*"
       }
     },
+    "node_modules/mobx": {
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
+      "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.0.tgz",
+      "integrity": "sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==",
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.0.tgz",
+      "integrity": "sha512-QEP10dpHHBeQNv1pks3WnHRCem2Zp636lq54M2nKO2Sarr13pL4u6diQXf65yzXUn0mkk18SyIDCm9UOJYTi1w==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2805,6 +2867,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "mobx": "^6.13.7",
+    "mobx-react": "^9.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "styled-components": "^6.1.19"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
+import { StoresContext, stores } from './stores';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <StoresContext.Provider value={stores}>
+      <App />
+    </StoresContext.Provider>
   </StrictMode>,
-)
+);

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -5,10 +5,18 @@ const manifestModules = import.meta.glob('./plugins/**/manifest.{js,jsx}', {
   import: 'default',
 });
 
+import { pluginStore } from './stores/PluginStore';
+
 // Turn the modules into a clean array/registry
 export const plugins = Object.entries(manifestModules).map(([path, manifest]) => ({
   ...manifest,
   _path: path, // useful for debugging
 }));
+
+plugins.forEach(plugin => {
+  if (plugin.Store) {
+    pluginStore.registerStore(plugin.id, new plugin.Store());
+  }
+});
 
 export const pluginById = Object.fromEntries(plugins.map(p => [p.id, p]));

--- a/src/plugins/hello/HelloStore.js
+++ b/src/plugins/hello/HelloStore.js
@@ -1,0 +1,18 @@
+import { makeObservable, observable, action } from 'mobx';
+import { GenericStore } from '../../stores/GenericStore';
+
+export class HelloStore extends GenericStore {
+  name = 'World';
+
+  constructor() {
+    super();
+    makeObservable(this, {
+      name: observable,
+      setName: action,
+    });
+  }
+
+  setName(name) {
+    this.name = name;
+  }
+}

--- a/src/plugins/hello/hello.jsx
+++ b/src/plugins/hello/hello.jsx
@@ -1,6 +1,23 @@
-import { HelloContainer } from "./hello.style.js";
+import { observer } from 'mobx-react';
+import { useStores_ } from '../../stores';
+import { HelloContainer } from './hello.style.js';
 
 // src/plugins/hello/index.jsx
-export default function Hello() {
-  return <HelloContainer>👋 Hello from the plugin.</HelloContainer>;
+function Hello() {
+  const { pluginStore } = useStores_();
+  const helloStore = pluginStore.getStore('hello');
+
+  return (
+    <HelloContainer>
+      👋 Hello {helloStore.name}
+      <br />
+      <input
+        type="text"
+        value={helloStore.name}
+        onChange={e => helloStore.setName(e.target.value)}
+      />
+    </HelloContainer>
+  );
 }
+
+export default observer(Hello);

--- a/src/plugins/hello/manifest.js
+++ b/src/plugins/hello/manifest.js
@@ -1,8 +1,11 @@
 // src/plugins/hello/manifest.js
+import { HelloStore } from './HelloStore';
+
 export default {
   id: 'hello',
   title: 'Hello',
   icon: '👋',
   // Lazy-load the plugin's root React component when needed
   load: () => import('./hello.jsx'),
+  Store: HelloStore,
 };

--- a/src/stores/GenericStore.js
+++ b/src/stores/GenericStore.js
@@ -1,0 +1,16 @@
+import { makeObservable, observable, action } from 'mobx';
+
+export class GenericStore {
+  data = {};
+
+  constructor() {
+    makeObservable(this, {
+      data: observable,
+      setData: action,
+    });
+  }
+
+  setData(data) {
+    this.data = { ...this.data, ...data };
+  }
+}

--- a/src/stores/PluginStore.js
+++ b/src/stores/PluginStore.js
@@ -1,0 +1,22 @@
+import { makeObservable, observable, action } from 'mobx';
+
+class PluginStore {
+  stores = {};
+
+  constructor() {
+    makeObservable(this, {
+      stores: observable,
+      registerStore: action,
+    });
+  }
+
+  registerStore(name, store) {
+    this.stores[name] = store;
+  }
+
+  getStore(name) {
+    return this.stores[name];
+  }
+}
+
+export const pluginStore = new PluginStore();

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+import { pluginStore } from './PluginStore';
+
+export const stores = {
+  pluginStore,
+};
+
+export const StoresContext = createContext(stores);
+
+export const useStores_ = () => useContext(StoresContext);


### PR DESCRIPTION
This commit installs MobX and MobX-React to the project.

It also adds a generic store that can be used as a base for plugin stores.

A new store is created for the `hello` plugin to demonstrate how to use the new store.